### PR TITLE
Fix: Panic - slice bounds out of range in viewport when displaying issues

### DIFF
--- a/aw.sh
+++ b/aw.sh
@@ -754,7 +754,7 @@ _aw_issue() {
       return 1
     fi
 
-    local selection=$(echo "$issues" | gum filter --height 20 --placeholder "Type to filter issues...")
+    local selection=$(echo "$issues" | gum filter --placeholder "Type to filter issues...")
 
     if [[ -z "$selection" ]]; then
       gum style --foreground 3 "Cancelled"
@@ -837,7 +837,7 @@ _aw_pr() {
       return 1
     fi
 
-    local selection=$(echo "$prs" | gum filter --height 20 --placeholder "Type to filter PRs... (✓=passing ✗=failing ○=pending)")
+    local selection=$(echo "$prs" | gum filter --placeholder "Type to filter PRs... (✓=passing ✗=failing ○=pending)")
 
     if [[ -z "$selection" ]]; then
       gum style --foreground 3 "Cancelled"


### PR DESCRIPTION
## Summary
- Removed the `--height 20` parameter from `gum filter` commands in both `_aw_issue` and `_aw_pr` functions
- This allows gum to automatically adjust to the available terminal space
- Prevents viewport panic when terminal window is too small

## Root Cause
The panic occurred in `github.com/charmbracelet/bubbles/viewport.Model.visibleLines` because the fixed height parameter caused the viewport height calculation to produce invalid slice bounds when the terminal was too small.

## Test plan
- [x] Run `auto-worktree issue` in a terminal of any size
- [x] Verify that the issues list displays without crashing
- [x] Run `auto-worktree pr` in a terminal of any size
- [x] Verify that the PRs list displays without crashing

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)