### PR TITLE
Add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,61 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior in auto-worktree
+title: ''
+labels: ''
+assignees: ''
+---
+
+## Bug Description
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Error Message
+
+If applicable, paste the full error message or stack trace:
+
+```
+[Paste error here]
+```
+
+## Environment
+
+- **Platform**: [e.g., darwin, linux]
+- **OS Version**: [e.g., Darwin 24.6.0, Ubuntu 22.04]
+- **Shell**: [e.g., zsh 5.9, bash 5.1]
+- **auto-worktree version/commit**: [e.g., commit abc123 or v1.0.0]
+
+### Installed Tools
+
+Which of the following are installed? (Check all that apply)
+
+- [ ] gh (GitHub CLI)
+- [ ] glab (GitLab CLI)
+- [ ] jira (JIRA CLI)
+- [ ] gum
+- [ ] jq
+- [ ] claude (Claude Code)
+- [ ] codex (Codex CLI)
+- [ ] gemini (Gemini CLI)
+
+## Additional Context
+
+Any other context about the problem, screenshots, or relevant configuration.
+
+## Suggested Labels
+
+Consider adding: `bug`, `devxp`, `vendor` (if vendor-specific)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,56 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement for auto-worktree
+title: ''
+labels: 'enhancement'
+assignees: ''
+---
+
+## Feature Description
+
+A clear and concise description of the feature you'd like to see.
+
+## Use Case
+
+What problem does this solve? When would you use this feature?
+
+## Proposed Solution
+
+How do you envision this working? (Optional - feel free to leave this to the maintainers)
+
+## Vendor/Integration Specific
+
+Is this feature related to a specific vendor or tool integration?
+
+- [ ] GitHub (gh CLI)
+- [ ] GitLab (glab CLI)
+- [ ] JIRA (jira CLI)
+- [ ] Claude Code
+- [ ] Codex CLI
+- [ ] Gemini CLI
+- [ ] Other AI CLI: [specify]
+- [ ] Not vendor-specific
+
+## Type of Feature
+
+What category does this feature fall into?
+
+- [ ] New integration/vendor support
+- [ ] Enhancement to existing functionality
+- [ ] Developer experience improvement
+- [ ] CI/CD or release engineering
+- [ ] Interactive menu/UI improvement
+- [ ] AI agent integration
+- [ ] Other: [specify]
+
+## Additional Context
+
+Any other context, screenshots, examples from other tools, or references.
+
+## Alternatives Considered
+
+Have you considered any alternative solutions or workarounds?
+
+## Suggested Labels
+
+Consider adding: `enhancement`, `devxp`, `vendor`, `ci`, `release engineering`


### PR DESCRIPTION
## Summary

- Created `.github/ISSUE_TEMPLATE/bug_report.md` with sections for reproduction steps, environment details, error messages, and installed tools checklist
- Created `.github/ISSUE_TEMPLATE/feature_request.md` with sections for use cases, vendor integrations, feature categorization, and alternatives
- Both templates include label suggestions matching the project's existing taxonomy (enhancement, devxp, vendor, ci, release engineering)

Templates were designed by analyzing existing issues (#21, #11, #9, #10, #17, #18, #20, #34) to identify common patterns and information needs.

## Test plan

- [ ] Create a new GitHub issue and verify both templates appear as options
- [ ] Select the Bug Report template and verify all sections render correctly
- [ ] Select the Feature Request template and verify all sections render correctly
- [ ] Verify label suggestions are helpful for categorizing issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)