### PR TITLE
Fix cross-platform timestamp bug in worktree age calculation (#42)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,8 @@ _aw_sanitize_branch_name() {
 
 ### Worktree Age Calculation
 - Uses commit timestamp from `git log -1 --format=%ct`
-- Falls back to file modification time if no commits
+- Falls back to file modification time if no commits (via `_aw_get_file_mtime` helper)
+- Cross-platform support: macOS/BSD (`stat -f %m`) and Linux (`stat -c %Y`)
 - Age thresholds:
   - `<1 day`: Green, shows hours (e.g., `[2h ago]`)
   - `1-4 days`: Yellow, shows days (e.g., `[3d ago]`)


### PR DESCRIPTION
## Summary
Fixes #42 - Resolves cross-platform compatibility issue where worktree ages displayed as `[unknown]` on Linux systems.

## Changes
- **Added** `_aw_get_file_mtime()` helper function that detects OS and uses appropriate stat syntax
  - macOS/BSD: `stat -f %m`
  - Linux: `stat -c %Y`
- **Fixed** timestamp fallback in 3 locations:
  - `_aw_list()` function (aw.sh:1741)
  - `_aw_resume()` function (aw.sh:2720)
  - `_aw_cleanup_interactive()` function (aw.sh:2842)
- **Updated** AGENTS.md documentation to reflect cross-platform support

## Problem
The worktree age calculation was using `stat -f %m` which is macOS/BSD-specific syntax. On Linux systems, this command fails silently, causing the timestamp to be empty and ages to display as `[unknown]` instead of showing actual time values like `[2h ago]` or `[3d ago]`.

## Solution
Created a cross-platform helper function that detects the operating system using `uname` and uses the correct stat command syntax for each platform.

## Test Plan
- [x] Syntax validation passes (`zsh -n aw.sh`)
- [x] Helper function returns valid Unix timestamps on macOS
- [x] All 3 instances of the bug have been fixed
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)