### PR TITLE
Add automatic git hooks execution during worktree setup

### DIFF
--- a/aw.sh
+++ b/aw.sh
@@ -21,6 +21,9 @@
 #   git config auto-worktree.ai-tool <name>                     # claude|codex|gemini|jules|skip
 #   git config auto-worktree.issue-autoselect <bool>            # true/false for AI auto-select
 #   git config auto-worktree.pr-autoselect <bool>               # true/false for AI auto-select
+#   git config auto-worktree.run-hooks <bool>                   # true/false to enable/disable git hooks (default: true)
+#   git config auto-worktree.fail-on-hook-error <bool>          # true/false to fail on hook errors (default: false)
+#   git config auto-worktree.custom-hooks "<hook1> <hook2>"     # Space or comma-separated list of custom hooks to run
 
 # ============================================================================
 # Dependencies check
@@ -1471,12 +1474,180 @@ _aw_prompt_issue_provider() {
   esac
 }
 
+_aw_find_hook_paths() {
+  # Find all possible hook directories
+  # Returns paths separated by newlines
+  local worktree_path="$1"
+  local hook_paths=()
+
+  # 1. Check custom git config core.hooksPath
+  local custom_hooks_path=$(git -C "$worktree_path" config core.hooksPath 2>/dev/null)
+  if [[ -n "$custom_hooks_path" ]]; then
+    # Handle both absolute and relative paths
+    if [[ "$custom_hooks_path" == /* ]]; then
+      hook_paths+=("$custom_hooks_path")
+    else
+      hook_paths+=("$worktree_path/$custom_hooks_path")
+    fi
+  fi
+
+  # 2. Check .husky directory (popular Node.js hook manager)
+  if [[ -d "$worktree_path/.husky" ]]; then
+    hook_paths+=("$worktree_path/.husky")
+  fi
+
+  # 3. Standard .git/hooks directory
+  # For worktrees, use --git-common-dir to get the shared hooks directory
+  local git_common_dir=$(git -C "$worktree_path" rev-parse --git-common-dir 2>/dev/null)
+  if [[ -n "$git_common_dir" && -d "$git_common_dir/hooks" ]]; then
+    hook_paths+=("$git_common_dir/hooks")
+  fi
+
+  # Print paths (one per line)
+  for path in "${hook_paths[@]}"; do
+    echo "$path"
+  done
+}
+
+_aw_execute_hook() {
+  # Execute a single git hook if it exists and is executable
+  # Returns 0 on success, 1 on failure, 2 if hook doesn't exist
+  local hook_path="$1"
+  local worktree_path="$2"
+  local hook_name=$(basename "$hook_path")
+
+  if [[ ! -f "$hook_path" ]]; then
+    return 2  # Hook doesn't exist
+  fi
+
+  if [[ ! -x "$hook_path" ]]; then
+    return 2  # Hook not executable
+  fi
+
+  # Display hook execution
+  echo ""
+  gum style --foreground 6 "Running git hook: $hook_name"
+
+  # Execute hook in worktree context
+  # Pass standard git hook parameters for post-checkout: <prev-head> <new-head> <branch-flag>
+  # For worktree creation, we use: 0000000000000000000000000000000000000000 HEAD 1
+  local prev_head="0000000000000000000000000000000000000000"
+  local new_head=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null || echo "HEAD")
+  local branch_flag="1"  # 1 = branch checkout, 0 = file checkout
+
+  # Run hook with output displayed directly to user
+  if (cd "$worktree_path" && "$hook_path" "$prev_head" "$new_head" "$branch_flag"); then
+    gum style --foreground 2 "✓ Hook $hook_name completed successfully"
+    return 0
+  else
+    return 1
+  fi
+}
+
+_aw_run_git_hooks() {
+  # Run git hooks during worktree setup
+  # Executes hooks in order: post-checkout, post-clone, post-worktree, custom hooks
+  local worktree_path="$1"
+
+  # Check if hook execution is enabled (default: true)
+  local run_hooks=$(git -C "$worktree_path" config --bool auto-worktree.run-hooks 2>/dev/null)
+  if [[ "$run_hooks" == "false" ]]; then
+    return 0
+  fi
+
+  # Get failure handling preference (default: false = warn only)
+  local fail_on_error=$(git -C "$worktree_path" config --bool auto-worktree.fail-on-hook-error 2>/dev/null)
+  if [[ -z "$fail_on_error" ]]; then
+    fail_on_error="false"
+  fi
+
+  # Find all hook directories
+  local hook_paths=()
+  while IFS= read -r path; do
+    hook_paths+=("$path")
+  done < <(_aw_find_hook_paths "$worktree_path")
+
+  if [[ ${#hook_paths[@]} -eq 0 ]]; then
+    # No hook directories found, skip silently
+    return 0
+  fi
+
+  # Define hooks to run in order
+  local hooks_to_run=("post-checkout" "post-clone" "post-worktree")
+
+  # Check for custom hooks config
+  local custom_hooks=$(git -C "$worktree_path" config auto-worktree.custom-hooks 2>/dev/null)
+  if [[ -n "$custom_hooks" ]]; then
+    # Add custom hooks (space or comma separated)
+    IFS=', ' read -ra custom_array <<< "$custom_hooks"
+    hooks_to_run+=("${custom_array[@]}")
+  fi
+
+  local any_hook_ran=false
+  local any_hook_failed=false
+  local failed_hooks=()
+
+  # Execute each hook in order
+  for hook_name in "${hooks_to_run[@]}"; do
+    local hook_found=false
+
+    # Try to find and execute the hook in each hook directory
+    for hook_dir in "${hook_paths[@]}"; do
+      local hook_path="$hook_dir/$hook_name"
+
+      _aw_execute_hook "$hook_path" "$worktree_path"
+      local result=$?
+
+      if [[ $result -eq 0 ]]; then
+        # Hook succeeded
+        hook_found=true
+        any_hook_ran=true
+        break  # Don't run same hook from other directories
+      elif [[ $result -eq 1 ]]; then
+        # Hook failed
+        hook_found=true
+        any_hook_ran=true
+        any_hook_failed=true
+        failed_hooks+=("$hook_name")
+
+        # Display error with config hint
+        echo ""
+        gum style --foreground 1 "✗ Hook $hook_name failed"
+        if [[ "$fail_on_error" == "true" ]]; then
+          gum style --foreground 3 "To continue despite hook failures, run:"
+          gum style --foreground 7 "  git config auto-worktree.fail-on-hook-error false"
+          return 1
+        else
+          gum style --foreground 3 "⚠ Continuing despite hook failure (auto-worktree.fail-on-hook-error=false)"
+          gum style --foreground 7 "  To fail on hook errors, run: git config auto-worktree.fail-on-hook-error true"
+        fi
+        break  # Don't try other directories for this hook
+      fi
+      # result == 2 means hook doesn't exist, continue to next directory
+    done
+  done
+
+  if [[ "$any_hook_ran" == "true" ]]; then
+    echo ""
+  fi
+
+  return 0
+}
+
 _aw_setup_environment() {
   # Automatically set up the development environment based on detected project files
   local worktree_path="$1"
 
   if [[ ! -d "$worktree_path" ]]; then
     return 0
+  fi
+
+  # Run git hooks before dependency installation
+  _aw_run_git_hooks "$worktree_path"
+  local hook_result=$?
+  if [[ $hook_result -ne 0 ]]; then
+    # Hook failed and fail-on-hook-error is true
+    return 1
   fi
 
   local setup_ran=false


### PR DESCRIPTION
## Summary

Implements automatic discovery and execution of git hooks during worktree creation to ensure complete environment initialization. This addresses issue #51 by running hooks before dependency installation, making worktrees immediately ready for work.

**Changes:**
- ✅ Automatic hook discovery in multiple locations (core.hooksPath, .husky/, .git/hooks/)
- ✅ Ordered execution: post-checkout → post-clone → post-worktree → custom hooks
- ✅ Configurable via git config with sensible defaults
- ✅ Smart failure handling with helpful config hints
- ✅ Direct output display for transparency
- ✅ Full worktree compatibility using git-common-dir

**Key Features:**

1. **Multi-location Hook Discovery**
   - Custom git config `core.hooksPath` (absolute or relative paths)
   - `.husky/` directory (popular Node.js hook manager)
   - Standard `.git/hooks/` directory (shared across worktrees)

2. **Configurable Behavior**
   ```bash
   git config auto-worktree.run-hooks <bool>              # Enable/disable (default: true)
   git config auto-worktree.fail-on-hook-error <bool>     # Fail on errors (default: false)
   git config auto-worktree.custom-hooks "<hook1> ..."    # Additional custom hooks
   ```

3. **User-Friendly Error Handling**
   - Warnings display current config and how to change it
   - Continues by default on hook failures (configurable)
   - Clear success/failure indicators

**Execution Flow:**
```
git worktree add 
    ↓
_aw_run_git_hooks() [NEW]
    ├─ post-checkout
    ├─ post-clone  
    ├─ post-worktree
    └─ custom hooks
    ↓
dependency installation
    ↓
AI agent launch
```

## Test Plan

- [x] Bash syntax validation (`bash -n aw.sh`)
- [x] Created test hooks: post-checkout and post-worktree
- [x] Verified hook discovery logic with git-common-dir
- [ ] Manual testing: Create new worktree and verify hooks execute
- [ ] Test with Husky hooks in .husky/
- [ ] Test custom hooks via git config
- [ ] Test failure handling (fail-on-hook-error true/false)
- [ ] Test with disabled hooks (run-hooks false)

## Documentation

- Updated header comments with new git config options
- Inline code documentation for all new functions
- Clear error messages with actionable config hints

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)