### PR TITLE
Fix mktemp to create unique temp files on macOS

### DIFF
--- a/aw.sh
+++ b/aw.sh
@@ -3154,13 +3154,19 @@ Output the issue body in markdown format."
   echo ""
 
   # Create output file (BSD/macOS compatible)
-  local output_file=$(mktemp /tmp/aw_issue_XXXXXX.md)
+  # On BSD/macOS, XXXXXX must be at the end of the template, so we create
+  # the temp file without .md extension and then rename it
+  local output_file=$(mktemp /tmp/aw_issue_XXXXXX)
 
   # Check if mktemp succeeded
   if [[ -z "$output_file" ]] || [[ ! -f "$output_file" ]]; then
     gum style --foreground 3 "Failed to create temporary file"
     return 1
   fi
+
+  # Add .md extension
+  mv "$output_file" "${output_file}.md"
+  output_file="${output_file}.md"
 
   # Execute AI in headless mode with -p flag
   if "${AI_CMD[@]}" -p "$ai_prompt" > "$output_file" 2>&1; then


### PR DESCRIPTION
## Summary
- Fixes the mktemp command to actually create unique temporary files on macOS
- Resolves the root cause of AI generation failures in issue #50

## Details

PR #53 attempted to fix mktemp BSD compatibility but used incorrect syntax. The command `mktemp /tmp/aw_issue_XXXXXX.md` creates a file **literally** named `/tmp/aw_issue_XXXXXX.md` on macOS instead of replacing XXXXXX with random characters.

**Root Cause:** On BSD/macOS, the `XXXXXX` pattern must be at the end of the template for mktemp to replace it. Since `.md` comes after `XXXXXX`, the pattern doesn't get replaced.

**The Fix:**
1. Create temp file without .md extension: `mktemp /tmp/aw_issue_XXXXXX`
2. Rename to add .md extension: `mv "$output_file" "${output_file}.md"`

This ensures unique temp files are created for each AI generation attempt, preventing:
- File conflicts between concurrent runs
- Stale data from previous attempts
- AI generation failures

## Testing
- ✅ Verified mktemp now creates unique files with random suffixes
- ✅ ShellCheck validation passes
- ✅ Bash syntax validation passes

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)