### PR TITLE
Simplify GitHub issue templates to be more problem-focused

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,60 +2,12 @@
 name: Bug Report
 about: Report a bug or unexpected behavior in auto-worktree
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 ---
 
-## Bug Description
+## What functionality was being used?
 
-A clear and concise description of what the bug is.
+## What information do we have (stacktrace, logs, screenshots)?
 
-## Steps to Reproduce
-
-1.
-2.
-3.
-
-## Expected Behavior
-
-What you expected to happen.
-
-## Actual Behavior
-
-What actually happened.
-
-## Error Message
-
-If applicable, paste the full error message or stack trace:
-
-```
-[Paste error here]
-```
-
-## Environment
-
-- **Platform**: [e.g., darwin, linux]
-- **OS Version**: [e.g., Darwin 24.6.0, Ubuntu 22.04]
-- **Shell**: [e.g., zsh 5.9, bash 5.1]
-- **auto-worktree version/commit**: [e.g., commit abc123 or v1.0.0]
-
-### Installed Tools
-
-Which of the following are installed? (Check all that apply)
-
-- [ ] gh (GitHub CLI)
-- [ ] glab (GitLab CLI)
-- [ ] jira (JIRA CLI)
-- [ ] gum
-- [ ] jq
-- [ ] claude (Claude Code)
-- [ ] codex (Codex CLI)
-- [ ] gemini (Gemini CLI)
-
-## Additional Context
-
-Any other context about the problem, screenshots, or relevant configuration.
-
-## Suggested Labels
-
-Consider adding: `bug`, `devxp`, `vendor` (if vendor-specific)
+## Any hypotheses to investigate?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,51 +6,8 @@ labels: 'enhancement'
 assignees: ''
 ---
 
-## Feature Description
+## What is the problem being solved?
 
-A clear and concise description of the feature you'd like to see.
+## What concepts or ideas do we need to explore to solve it?
 
-## Use Case
-
-What problem does this solve? When would you use this feature?
-
-## Proposed Solution
-
-How do you envision this working? (Optional - feel free to leave this to the maintainers)
-
-## Vendor/Integration Specific
-
-Is this feature related to a specific vendor or tool integration?
-
-- [ ] GitHub (gh CLI)
-- [ ] GitLab (glab CLI)
-- [ ] JIRA (jira CLI)
-- [ ] Claude Code
-- [ ] Codex CLI
-- [ ] Gemini CLI
-- [ ] Other AI CLI: [specify]
-- [ ] Not vendor-specific
-
-## Type of Feature
-
-What category does this feature fall into?
-
-- [ ] New integration/vendor support
-- [ ] Enhancement to existing functionality
-- [ ] Developer experience improvement
-- [ ] CI/CD or release engineering
-- [ ] Interactive menu/UI improvement
-- [ ] AI agent integration
-- [ ] Other: [specify]
-
-## Additional Context
-
-Any other context, screenshots, examples from other tools, or references.
-
-## Alternatives Considered
-
-Have you considered any alternative solutions or workarounds?
-
-## Suggested Labels
-
-Consider adding: `enhancement`, `devxp`, `vendor`, `ci`, `release engineering`
+## What labels should we tag this issue with?


### PR DESCRIPTION
## Summary
- Simplified feature request template to 3 focused questions
- Simplified bug report template to 3 focused questions
- Templates now start with the problem, not the solution
- Added 'bug' label to bug report template frontmatter

## Changes
**Feature Request Template:**
- What is the problem being solved?
- What concepts or ideas do we need to explore to solve it?
- What labels should we tag this issue with?

**Bug Report Template:**
- What functionality was being used?
- What information do we have (stacktrace, logs, screenshots)?
- Any hypotheses to investigate?

This makes templates more concise and easier to use with autoworktree create issue functionality.

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)