### PR TITLE
Fix worktree resume to handle missing conversations gracefully

### DIFF
--- a/aw.sh
+++ b/aw.sh
@@ -4529,7 +4529,18 @@ _aw_resume() {
   _resolve_ai_command || return 1
 
   if [[ "${AI_CMD[1]}" != "skip" ]]; then
-    "${AI_RESUME_CMD[@]}"
+    # Check if a conversation exists to resume
+    # Claude Code stores conversation history in .claude directory
+    if [[ -d ".claude" ]] || [[ -f ".claude.json" ]]; then
+      # Conversation exists, try to resume
+      "${AI_RESUME_CMD[@]}"
+    else
+      # No conversation found, start a fresh session
+      gum style --foreground 3 "No conversation found to continue"
+      gum style --foreground 6 "Starting fresh session in worktree..."
+      echo ""
+      "${AI_CMD[@]}"
+    fi
   else
     gum style --foreground 3 "Skipping AI tool - worktree is ready for manual work"
   fi


### PR DESCRIPTION
## Summary
Fixes the worktree resume workflow to gracefully handle cases when no existing conversation is found, instead of showing an error.

## Changes
- Added a check for the presence of `.claude` directory or `.claude.json` file before attempting to resume
- If no conversation exists, the tool now displays a friendly message and starts a fresh session
- If a conversation exists, it resumes as before using the `--continue` flag

## Test Plan
1. Create a new worktree without starting an AI session
2. Try to resume the worktree
3. Verify it starts a fresh session instead of showing an error

## Related Issue
Fixes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)