### PR TITLE
Fix git hook PATH environment to include system directories

### DIFF
--- a/aw.sh
+++ b/aw.sh
@@ -1535,8 +1535,15 @@ _aw_execute_hook() {
   local new_head=$(git -C "$worktree_path" rev-parse HEAD 2>/dev/null || echo "HEAD")
   local branch_flag="1"  # 1 = branch checkout, 0 = file checkout
 
+  # Set a safe PATH that includes standard system directories
+  # This ensures hooks have access to basic commands like basename, mkdir, date, etc.
+  local safe_path="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  if [[ -n "$PATH" ]]; then
+    safe_path="$PATH:$safe_path"
+  fi
+
   # Run hook with output displayed directly to user
-  if (cd "$worktree_path" && "$hook_path" "$prev_head" "$new_head" "$branch_flag"); then
+  if (cd "$worktree_path" && PATH="$safe_path" "$hook_path" "$prev_head" "$new_head" "$branch_flag"); then
     gum style --foreground 2 "✓ Hook $hook_name completed successfully"
     return 0
   else


### PR DESCRIPTION
## Summary
- Fixes git hooks failing during worktree creation due to missing PATH
- Resolves #65

## Problem
Git hooks were failing with "command not found" errors for basic system commands like `basename`, `mkdir`, and `date`. This was preventing worktree creation from completing successfully when git hooks were present.

## Root Cause
The `_aw_execute_hook()` function was executing hooks in a subshell without ensuring the PATH environment variable included standard system directories.

## Solution
Modified `aw.sh:1538-1546` to set a safe PATH that includes standard system directories before executing hooks:
- Adds `/usr/local/bin`, `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin` to PATH
- Preserves any existing PATH values by prepending them
- Ensures hooks have access to standard system commands

## Testing
- Shellcheck validation passes with no issues
- Code changes are minimal and focused on the specific problem

## Test plan
- [ ] Create a new worktree with git hooks present
- [ ] Verify hooks execute without "command not found" errors
- [ ] Confirm basic commands (basename, mkdir, date) work in hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)