### PR TITLE
Improve create issue workflow UX with better input prompts

### DIFF
--- a/aw.sh
+++ b/aw.sh
@@ -997,8 +997,9 @@ _aw_configure_issue_templates() {
 
   # Ask if user wants to specify custom directory
   if gum confirm "Specify a custom templates directory?"; then
-    local custom_dir=$(gum input --placeholder "$default_dir" \
-      --header "Templates directory path:")
+    echo ""
+    gum style --foreground 6 "Templates directory path:"
+    local custom_dir=$(gum input --placeholder "$default_dir")
 
     if [[ -n "$custom_dir" ]]; then
       if [[ -d "$custom_dir" ]]; then
@@ -1036,9 +1037,9 @@ _aw_configure_jira() {
 
   # Get JIRA server URL
   local current_server=$(_aw_get_jira_server)
+  gum style --foreground 6 "JIRA Server URL:"
   local server=$(gum input --placeholder "https://your-company.atlassian.net" \
-    --value "$current_server" \
-    --header "JIRA Server URL:")
+    --value "$current_server")
 
   if [[ -z "$server" ]]; then
     gum style --foreground 3 "Cancelled"
@@ -1049,9 +1050,10 @@ _aw_configure_jira() {
 
   # Get default JIRA project key
   local current_project=$(_aw_get_jira_project)
+  echo ""
+  gum style --foreground 6 "Default JIRA Project Key (optional, can filter issues):"
   local project=$(gum input --placeholder "PROJ" \
-    --value "$current_project" \
-    --header "Default JIRA Project Key (optional, can filter issues):")
+    --value "$current_project")
 
   if [[ -n "$project" ]]; then
     _aw_set_jira_project "$project"
@@ -3018,7 +3020,9 @@ _aw_create_issue_jira() {
   local project=$(_aw_get_jira_project)
 
   if [[ -z "$project" ]]; then
-    project=$(gum input --placeholder "PROJ" --header "JIRA Project Key:")
+    echo ""
+    gum style --foreground 6 "JIRA Project Key:"
+    project=$(gum input --placeholder "PROJ")
     if [[ -z "$project" ]]; then
       gum style --foreground 1 "Error: Project key is required"
       return 1
@@ -3053,7 +3057,9 @@ _aw_create_issue_linear() {
   local team=$(_aw_get_linear_team)
 
   if [[ -z "$team" ]]; then
-    team=$(gum input --placeholder "TEAM" --header "Linear Team Key:")
+    echo ""
+    gum style --foreground 6 "Linear Team Key:"
+    team=$(gum input --placeholder "TEAM")
     if [[ -z "$team" ]]; then
       gum style --foreground 1 "Error: Team key is required"
       return 1
@@ -3087,10 +3093,10 @@ _aw_manual_template_walkthrough() {
   # For now, use gum write to let user edit the template
   echo ""
   gum style --foreground 6 "Edit the issue template:"
+  gum style --foreground 8 "Fill in the template sections (Ctrl+D when done, Ctrl+C to cancel)"
   echo ""
 
-  body=$(echo "$template_content" | gum write --width 80 --height 20 \
-    --placeholder "Fill in the template sections (Ctrl+D when done, Ctrl+C to cancel)...")
+  body=$(echo "$template_content" | gum write --width 80 --height 20)
 
   # Check if user cancelled
   if [[ $? -ne 0 ]]; then
@@ -3247,8 +3253,9 @@ _aw_fill_template_section_by_section() {
     fi
 
     # Ask user to provide content for this section, pre-populated with template content
+    gum style --foreground 6 "Fill in or edit this section (Ctrl+D when done, Ctrl+C to cancel, leave blank to skip):"
+    echo ""
     local section_content=$(echo "$section_template_content" | gum write --width 80 --height 15 \
-      --placeholder "Fill in or edit this section (Ctrl+D when done, Ctrl+C to cancel)" \
       --char-limit 0)
 
     # Check if user cancelled
@@ -3256,11 +3263,13 @@ _aw_fill_template_section_by_section() {
       return 1
     fi
 
-    # Add section to filled content
-    filled_content+="## ${section_name}
+    # Only add section to filled content if it's not blank
+    if [[ -n "$section_content" ]]; then
+      filled_content+="## ${section_name}
 ${section_content}
 
 "
+    fi
   done <<< "$sections"
 
   echo "$filled_content"
@@ -3393,7 +3402,8 @@ _aw_create_issue() {
 
     # Get title/prompt
     echo ""
-    title=$(gum input --placeholder "Issue title or brief description" --header "Enter issue title/prompt:" --width 80)
+    gum style --foreground 6 "Enter issue title/prompt:"
+    title=$(gum input --placeholder "Issue title or brief description" --width 80)
 
     if [[ $? -ne 0 ]] || [[ -z "$title" ]]; then
       gum style --foreground 3 "Cancelled"
@@ -3452,8 +3462,9 @@ _aw_create_issue() {
               # Let user review and edit the AI-generated content
               echo ""
               gum style --foreground 6 "AI-generated content (review and edit if needed):"
-              body=$(cat "$ai_output_file" | gum write --width 80 --height 20 \
-                --placeholder "Review and edit AI-generated content (Ctrl+D when done, Ctrl+C to cancel)...")
+              gum style --foreground 8 "Ctrl+D when done, Ctrl+C to cancel"
+              echo ""
+              body=$(cat "$ai_output_file" | gum write --width 80 --height 20)
               if [[ $? -ne 0 ]]; then
                 rm "$ai_output_file"
                 gum style --foreground 3 "Issue creation cancelled"
@@ -3463,8 +3474,10 @@ _aw_create_issue() {
             else
               # Fall back to manual input
               echo ""
-              body=$(gum write --width 80 --height 15 \
-                --placeholder "Enter issue description (Ctrl+D to finish, Ctrl+C to cancel)...")
+              gum style --foreground 6 "Enter issue description:"
+              gum style --foreground 8 "Ctrl+D to finish, Ctrl+C to cancel"
+              echo ""
+              body=$(gum write --width 80 --height 15)
               if [[ $? -ne 0 ]]; then
                 gum style --foreground 3 "Issue creation cancelled"
                 return 0
@@ -3472,8 +3485,10 @@ _aw_create_issue() {
             fi
           else
             echo ""
-            body=$(gum write --width 80 --height 15 \
-              --placeholder "Enter issue description (Ctrl+D to finish, Ctrl+C to cancel)...")
+            gum style --foreground 6 "Enter issue description:"
+            gum style --foreground 8 "Ctrl+D to finish, Ctrl+C to cancel"
+            echo ""
+            body=$(gum write --width 80 --height 15)
             if [[ $? -ne 0 ]]; then
               gum style --foreground 3 "Issue creation cancelled"
               return 0
@@ -3492,8 +3507,9 @@ _aw_create_issue() {
                 # Let user review and edit AI-generated content
                 echo ""
                 gum style --foreground 6 "AI-generated content (review and edit if needed):"
-                body=$(cat "$ai_output_file" | gum write --width 80 --height 20 --char-limit 0 \
-                  --placeholder "Review and edit AI-generated content (Ctrl+D when done, Ctrl+C to cancel)...")
+                gum style --foreground 8 "Ctrl+D when done, Ctrl+C to cancel"
+                echo ""
+                body=$(cat "$ai_output_file" | gum write --width 80 --height 20 --char-limit 0)
                 if [[ $? -ne 0 ]]; then
                   rm "$ai_output_file"
                   gum style --foreground 3 "Issue creation cancelled"
@@ -3541,8 +3557,9 @@ _aw_create_issue() {
           if [[ -n "$ai_output_file" ]] && [[ -f "$ai_output_file" ]]; then
             echo ""
             gum style --foreground 6 "AI-generated content (review and edit if needed):"
-            body=$(cat "$ai_output_file" | gum write --width 80 --height 20 \
-              --placeholder "Review and edit AI-generated content (Ctrl+D when done, Ctrl+C to cancel)...")
+            gum style --foreground 8 "Ctrl+D when done, Ctrl+C to cancel"
+            echo ""
+            body=$(cat "$ai_output_file" | gum write --width 80 --height 20)
             if [[ $? -ne 0 ]]; then
               rm "$ai_output_file"
               gum style --foreground 3 "Issue creation cancelled"
@@ -3551,8 +3568,10 @@ _aw_create_issue() {
             rm "$ai_output_file"
           else
             echo ""
-            body=$(gum write --width 80 --height 15 \
-              --placeholder "Enter issue description (Ctrl+D to finish, Ctrl+C to cancel)...")
+            gum style --foreground 6 "Enter issue description:"
+            gum style --foreground 8 "Ctrl+D to finish, Ctrl+C to cancel"
+            echo ""
+            body=$(gum write --width 80 --height 15)
             if [[ $? -ne 0 ]]; then
               gum style --foreground 3 "Issue creation cancelled"
               return 0
@@ -3560,8 +3579,10 @@ _aw_create_issue() {
           fi
         else
           echo ""
-          body=$(gum write --width 80 --height 15 \
-            --placeholder "Enter issue description (Ctrl+D to finish)...")
+          gum style --foreground 6 "Enter issue description:"
+          gum style --foreground 8 "Ctrl+D to finish"
+          echo ""
+          body=$(gum write --width 80 --height 15)
           if [[ $? -ne 0 ]]; then
             gum style --foreground 3 "Issue creation cancelled"
             return 0
@@ -3576,8 +3597,9 @@ _aw_create_issue() {
         if [[ -n "$ai_output_file" ]] && [[ -f "$ai_output_file" ]]; then
           echo ""
           gum style --foreground 6 "AI-generated content (review and edit if needed):"
-          body=$(cat "$ai_output_file" | gum write --width 80 --height 20 \
-            --placeholder "Review and edit AI-generated content (Ctrl+D when done, Ctrl+C to cancel)...")
+          gum style --foreground 8 "Ctrl+D when done, Ctrl+C to cancel"
+          echo ""
+          body=$(cat "$ai_output_file" | gum write --width 80 --height 20)
           if [[ $? -ne 0 ]]; then
             rm "$ai_output_file"
             gum style --foreground 3 "Issue creation cancelled"
@@ -3586,8 +3608,10 @@ _aw_create_issue() {
           rm "$ai_output_file"
         else
           echo ""
-          body=$(gum write --width 80 --height 15 \
-            --placeholder "Enter issue description (Ctrl+D to finish)...")
+          gum style --foreground 6 "Enter issue description:"
+          gum style --foreground 8 "Ctrl+D to finish"
+          echo ""
+          body=$(gum write --width 80 --height 15)
           if [[ $? -ne 0 ]]; then
             gum style --foreground 3 "Issue creation cancelled"
             return 0
@@ -3595,8 +3619,10 @@ _aw_create_issue() {
         fi
       else
         echo ""
-        body=$(gum write --width 80 --height 15 \
-          --placeholder "Enter issue description (Ctrl+D to finish)...")
+        gum style --foreground 6 "Enter issue description:"
+        gum style --foreground 8 "Ctrl+D to finish"
+        echo ""
+        body=$(gum write --width 80 --height 15)
         if [[ $? -ne 0 ]]; then
           gum style --foreground 3 "Issue creation cancelled"
           return 0
@@ -3996,7 +4022,8 @@ _aw_issue() {
   fi
 
   echo ""
-  local branch_name=$(gum input --value "$suggested" --placeholder "Branch name" --header "Confirm branch name:")
+  gum style --foreground 6 "Confirm branch name:"
+  local branch_name=$(gum input --value "$suggested" --placeholder "Branch name")
 
   if [[ -z "$branch_name" ]]; then
     gum style --foreground 3 "Cancelled"


### PR DESCRIPTION
## Summary
- Separated questions from input fields for clearer user interaction
- Removed `--header` parameters from all `gum input` calls and added dedicated prompt lines
- Moved placeholder instructions out of `gum write` calls to separate styled lines
- Template sections can now be skipped by leaving them blank, improving flexibility

## Changes
- **Input prompts**: All `gum input` calls now display questions on separate lines using `gum style`, making the prompts clearer and easier to read
- **Write prompts**: All `gum write` calls have instructions displayed separately, not in placeholders
- **Blank sections**: Template section-by-section workflow now skips empty sections instead of including them with blank content

## Test plan
- [x] Test create issue workflow with templates (section-by-section flow)
- [x] Test create issue workflow without templates
- [x] Verify blank sections are properly omitted
- [x] Test JIRA and Linear configuration flows
- [x] Verify all prompts display correctly on separate lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)