### PR TITLE
Fix type assertion errors in Create Issue command (Issue #119)

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -543,7 +543,7 @@ func RunCreate() error {
 		return fmt.Errorf("error getting confirmation: %w", err)
 	}
 
-	confirmed, ok := result.(*ui.ConfirmModel)
+	confirmed, ok := result.(ui.ConfirmModel)
 	if !ok {
 		return fmt.Errorf("unexpected model type")
 	}
@@ -573,7 +573,7 @@ func RunCreate() error {
 		return fmt.Errorf("error getting worktree confirmation: %w", err)
 	}
 
-	wtConfirmed, ok := result.(*ui.ConfirmModel)
+	wtConfirmed, ok := result.(ui.ConfirmModel)
 	if !ok {
 		return fmt.Errorf("unexpected model type")
 	}
@@ -1257,7 +1257,7 @@ func resetSettings(cfg *git.Config) error {
 		return fmt.Errorf("failed to run confirmation: %w", err)
 	}
 
-	confirmModel, ok := model.(*ui.ConfirmModel)
+	confirmModel, ok := model.(ui.ConfirmModel)
 	if !ok {
 		return fmt.Errorf("unexpected model type")
 	}

--- a/internal/ui/confirm.go
+++ b/internal/ui/confirm.go
@@ -18,8 +18,8 @@ type ConfirmModel struct {
 }
 
 // NewConfirmModel creates a new confirmation dialog
-func NewConfirmModel(prompt string) *ConfirmModel {
-	return &ConfirmModel{
+func NewConfirmModel(prompt string) ConfirmModel {
+	return ConfirmModel{
 		prompt:   prompt,
 		selected: 1, // Default to "No" for safety
 	}


### PR DESCRIPTION
## Summary
Fixed type assertion errors that caused the "Create Issue" command to fail with "unexpected model type" error when attempting to create GitHub issues.

## Root Cause
The `NewConfirmModel()` function was returning a pointer type (`*ConfirmModel`) while the code in `RunCreate()` was performing type assertions expecting a value type (`ui.ConfirmModel`). This mismatch caused the type assertion to fail at runtime.

## Changes
- Updated `NewConfirmModel()` to return a value type instead of a pointer, making it consistent with other UI component constructors
- Updated type assertions in `RunCreate()` to expect value types instead of pointers
- Applied the same fix to `resetSettings()` function which had the same issue

## Testing
- All unit tests pass with race detection enabled
- Linting passes with no errors
- Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)