### PR TITLE
Fix issue #128: Filter main branch from resume worktree list

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -118,8 +118,9 @@ func RunList() error {
 		return fmt.Errorf("error: %w", err)
 	}
 
-	// Use ListWorktreesWithMergeStatus to get merge status information
-	worktrees, err := repo.ListWorktreesWithMergeStatus()
+	// Use ListWorktreesWithMergeStatusExcludingMain to get merge status information,
+	// excluding the main repository root
+	worktrees, err := repo.ListWorktreesWithMergeStatusExcludingMain()
 	if err != nil {
 		return fmt.Errorf("error listing worktrees: %w", err)
 	}
@@ -398,8 +399,8 @@ func RunResume() error {
 
 	sessionMgr := session.NewManager()
 
-	// Get all worktrees
-	worktrees, err := repo.ListWorktreesWithMergeStatus()
+	// Get all worktrees, excluding the main repository root
+	worktrees, err := repo.ListWorktreesWithMergeStatusExcludingMain()
 	if err != nil {
 		return fmt.Errorf("error listing worktrees: %w", err)
 	}


### PR DESCRIPTION
## Summary
Prevents the main/root repository clone from appearing in worktree listings and the resume selection menu.

## Changes
- Add `FilterOutMainBranch()` helper method to centralize filtering logic
- Add `ListWorktreesWithMergeStatusExcludingMain()` for listing worktrees without root repo
- Update `RunList()` command to exclude main repository
- Update `RunResume()` command to exclude main repository from selection menu
- Refactor `GetCleanupCandidates()` to use shared filtering logic

## Test plan
- [x] All existing tests pass
- [x] Project builds successfully
- [x] Resume worktree command no longer lists the main branch

## Closes
Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)