### PR TITLE
Implement automatic startup cleanup of orphaned and merged worktrees (Issue #131)

### DIFF
--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -262,8 +262,18 @@ func (w *Worktree) ShouldCleanup() bool {
 	return w.IsMerged() || w.IsStale()
 }
 
+// IsOrphaned returns true if the worktree path doesn't exist or is broken
+func (w *Worktree) IsOrphaned() bool {
+	// Check if the path exists
+	_, err := os.Stat(w.Path)
+	return os.IsNotExist(err)
+}
+
 // CleanupReason returns a string describing why this worktree should be cleaned up
 func (w *Worktree) CleanupReason() string {
+	if w.IsOrphaned() {
+		return "orphaned"
+	}
 	if w.IsMerged() {
 		if w.IssueStatus != nil {
 			return fmt.Sprintf("merged (#%s)", w.IssueStatus.ID)


### PR DESCRIPTION
## Summary
Automatically clean up orphaned worktrees (broken symlinks/missing directories) and offer interactive cleanup for merged worktrees on every startup.

## Changes
- **Orphaned Detection**: Added `IsOrphaned()` method to detect and automatically clean up missing worktree directories with user feedback
- **Startup Cleanup Command**: New `RunStartupCleanup()` that categorizes worktrees by type and handles them appropriately
- **Interactive Merged Cleanup**: Users can choose to skip, delete, or delete with branch cleanup for merged worktrees
- **Integration**: Replaced silent git worktree prune with user-friendly startup cleanup flow

## Test Plan
- [x] Code compiles successfully
- [x] All existing tests pass (no failures)
- [x] Linter passes with no errors
- [x] Manual testing of startup cleanup flow
- [x] Verify orphaned detection works correctly
- [x] Verify merged worktree interactive prompt works

🤖 Generated with [Claude Code](https://claude.com/claude-code)