### PR TITLE
fix: Use alt screen for main menu to prevent visual artifacts

### DIFF
--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -67,7 +67,7 @@ func showInteractiveMenu() (bool, error) {
 	endMenuCreate()
 
 	endProgramCreate := perf.StartSpan("tea-program-create")
-	p := tea.NewProgram(menu)
+	p := tea.NewProgram(menu, tea.WithAltScreen())
 	endProgramCreate()
 
 	perf.Mark("menu-ready-to-render")
@@ -2549,7 +2549,7 @@ func RunSessions() error {
 
 	// Show the sessions list
 	list := ui.NewSessionList("Active Tmux Sessions", items)
-	p := tea.NewProgram(list)
+	p := tea.NewProgram(list, tea.WithAltScreen())
 
 	m, err := p.Run()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `tea.WithAltScreen()` to main menu to use alternate terminal buffer
- Add `tea.WithAltScreen()` to session list for consistency
- Fixes visual artifacts when returning to menu after commands that print output

## Problem
When selecting menu options like "View Tmux Sessions" that print output before returning to the menu, the previous menu state and output remained visible on screen, creating a messy display.

## Solution
Using `tea.WithAltScreen()` switches to an alternate terminal buffer for the menu. When the menu exits to run a command, the terminal restores to the normal buffer. When the menu loop re-displays, it switches back to the clean alternate buffer.

## Test plan
- [x] Build succeeds
- [x] All tests pass
- [x] Linter shows no issues
- [ ] Manual test: Select "View Tmux Sessions" with no sessions → menu redisplays cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)