### PR TITLE
feat: preserve user shell and auto-invoke AI provider in new worktree sessions

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -402,6 +402,38 @@ func escapeAppleScript(s string) string {
 	return s
 }
 
+// GetUserShell returns the user's default shell.
+// It first checks the SHELL environment variable, then falls back to /bin/sh.
+func GetUserShell() string {
+	shell := os.Getenv("SHELL")
+	if shell != "" {
+		return shell
+	}
+	// Fallback to /bin/sh if SHELL is not set
+	return "/bin/sh"
+}
+
+// GetShellCommand returns the shell command to use for tmux sessions.
+// If configuredShell is provided (from git config), it uses that.
+// Otherwise, it returns the user's default shell.
+func GetShellCommand(configuredShell string) []string {
+	if configuredShell != "" {
+		// If configured shell is a path, use it directly
+		// If it's just a shell name (e.g., "zsh"), try to find it in PATH
+		if strings.HasPrefix(configuredShell, "/") {
+			return []string{configuredShell}
+		}
+		// Try to find the shell in PATH
+		if path, err := exec.LookPath(configuredShell); err == nil {
+			return []string{path}
+		}
+		// Fall back to using the name directly
+		return []string{configuredShell}
+	}
+
+	return []string{GetUserShell()}
+}
+
 // SaveSessionMetadata saves metadata for a session
 func (m *SessionManager) SaveSessionMetadata(metadata *Metadata) error {
 	if m.metadataStore == nil {


### PR DESCRIPTION
## Summary
- Add shell detection and configuration support for tmux sessions - tmux sessions now start with user's preferred shell instead of hardcoded bash
- Implement automatic AI coding assistant launch after worktree/session creation
- Add interactive AI tool selection when multiple providers are installed but none is configured

## Changes
- `internal/session/session.go`: Added `GetUserShell()` and `GetShellCommand()` helpers
- `internal/cmd/commands.go`: 
  - Updated session creation to use configured/user shell
  - Added `startAIInSession()` to launch AI tools automatically
  - Added `selectAIToolInteractive()` for multi-provider selection
  - Added `saveAIToolChoice()` to persist user preference
  - Added `sendCommandToSession()` to send commands to tmux sessions

## Configuration
- `auto-worktree.tmux-shell` - Configure preferred shell for tmux sessions (optional, defaults to $SHELL)
- `auto-worktree.ai-tool` - Configure preferred AI tool: `claude`, `codex`, `gemini`, `jules`, or `skip`

## Test plan
- [ ] Create new worktree and verify it starts with zsh (or user's shell) instead of bash
- [ ] Verify Claude Code (or configured AI tool) is automatically launched in the session
- [ ] Test with multiple AI tools installed - should prompt for selection
- [ ] Test with `auto-worktree.ai-tool=skip` - should not launch any AI tool
- [ ] Verify preference is saved after selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)