### PR TITLE
Add platform-specific provider dependency install instructions

### DIFF
--- a/internal/cmd/install_instructions.go
+++ b/internal/cmd/install_instructions.go
@@ -1,0 +1,175 @@
+// Package cmd provides command-line interface handlers for auto-worktree operations.
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// Platform represents the operating system type
+type Platform string
+
+// Platform constants for supported operating systems
+const (
+	PlatformMacOS   Platform = "darwin"
+	PlatformLinux   Platform = "linux"
+	PlatformWindows Platform = "windows"
+)
+
+// InstallOption represents a single installation method
+type InstallOption struct {
+	Platform Platform // Empty means "Other" or cross-platform
+	Label    string   // Display label (e.g., "macOS", "Linux", "Other")
+	Command  string   // Install command or instruction
+	IsURL    bool     // If true, Command is a URL to documentation
+}
+
+// ProviderInstallInfo contains installation and configuration instructions for a provider
+type ProviderInstallInfo struct {
+	CLIName        string          // Name of the CLI tool (e.g., "gh", "glab")
+	ProviderName   string          // Human-readable name (e.g., "GitHub", "GitLab")
+	InstallOptions []InstallOption // Platform-specific install options
+	AuthSteps      []string        // Post-install authentication/configuration steps
+}
+
+// GetCurrentPlatform returns the current operating system platform
+func GetCurrentPlatform() Platform {
+	return Platform(runtime.GOOS)
+}
+
+// FormatNotInstalledError formats an error message for when a CLI is not installed
+func (p *ProviderInstallInfo) FormatNotInstalledError() string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("%s CLI is not installed.\n\n", p.CLIName))
+	sb.WriteString("Install with:\n")
+
+	currentPlatform := GetCurrentPlatform()
+	options := p.getRelevantOptions(currentPlatform)
+
+	for _, opt := range options {
+		if opt.IsURL {
+			sb.WriteString(fmt.Sprintf("  %s: See %s\n", opt.Label, opt.Command))
+		} else {
+			sb.WriteString(fmt.Sprintf("  %s: %s\n", opt.Label, opt.Command))
+		}
+	}
+
+	if len(p.AuthSteps) > 0 {
+		sb.WriteString("\nAfter installation:\n")
+
+		for _, step := range p.AuthSteps {
+			sb.WriteString(fmt.Sprintf("  %s\n", step))
+		}
+	}
+
+	return strings.TrimSuffix(sb.String(), "\n")
+}
+
+// FormatNotAuthenticatedError formats an error message for when a CLI is not authenticated
+func (p *ProviderInstallInfo) FormatNotAuthenticatedError() string {
+	if len(p.AuthSteps) == 0 {
+		return fmt.Sprintf("%s CLI is not authenticated", p.CLIName)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s CLI is not authenticated.\n\n", p.CLIName))
+
+	if len(p.AuthSteps) == 1 {
+		sb.WriteString(fmt.Sprintf("Run: %s", p.AuthSteps[0]))
+	} else {
+		sb.WriteString("Configure with:\n")
+
+		for _, step := range p.AuthSteps {
+			sb.WriteString(fmt.Sprintf("  %s\n", step))
+		}
+	}
+
+	return strings.TrimSuffix(sb.String(), "\n")
+}
+
+// getRelevantOptions returns install options relevant to the current platform
+func (p *ProviderInstallInfo) getRelevantOptions(current Platform) []InstallOption {
+	relevant := make([]InstallOption, 0, len(p.InstallOptions))
+	otherOptions := make([]InstallOption, 0, len(p.InstallOptions))
+
+	for _, opt := range p.InstallOptions {
+		switch opt.Platform {
+		case current:
+			relevant = append(relevant, opt)
+		case "":
+			otherOptions = append(otherOptions, opt)
+		}
+	}
+
+	// If we have platform-specific options, show those first, then "Other" options
+	// If no platform-specific options, show all "Other" options
+	if len(relevant) > 0 {
+		return append(relevant, otherOptions...)
+	}
+
+	// No platform-specific match, show all options
+	return append(relevant, p.InstallOptions...)
+}
+
+// Provider-specific install information
+
+// GitHubInstallInfo returns installation info for GitHub CLI
+func GitHubInstallInfo() *ProviderInstallInfo {
+	return &ProviderInstallInfo{
+		CLIName:      "gh",
+		ProviderName: "GitHub",
+		InstallOptions: []InstallOption{
+			{Platform: PlatformMacOS, Label: "macOS", Command: "brew install gh"},
+			{Platform: PlatformLinux, Label: "Linux", Command: "See https://github.com/cli/cli/blob/trunk/docs/install_linux.md", IsURL: true},
+			{Platform: PlatformWindows, Label: "Windows", Command: "winget install GitHub.cli"},
+		},
+		AuthSteps: []string{"gh auth login"},
+	}
+}
+
+// GitLabInstallInfo returns installation info for GitLab CLI
+func GitLabInstallInfo() *ProviderInstallInfo {
+	return &ProviderInstallInfo{
+		CLIName:      "glab",
+		ProviderName: "GitLab",
+		InstallOptions: []InstallOption{
+			{Platform: PlatformMacOS, Label: "macOS", Command: "brew install glab"},
+			{Platform: PlatformLinux, Label: "Linux", Command: "See https://gitlab.com/gitlab-org/cli#installation", IsURL: true},
+			{Platform: PlatformWindows, Label: "Windows", Command: "scoop install glab"},
+		},
+		AuthSteps: []string{"glab auth login"},
+	}
+}
+
+// JIRAInstallInfo returns installation info for JIRA CLI
+func JIRAInstallInfo() *ProviderInstallInfo {
+	return &ProviderInstallInfo{
+		CLIName:      "jira",
+		ProviderName: "JIRA",
+		InstallOptions: []InstallOption{
+			{Platform: PlatformMacOS, Label: "macOS", Command: "brew install ankitpokhrel/jira-cli/jira-cli"},
+			{Platform: PlatformLinux, Label: "Linux", Command: "See https://github.com/ankitpokhrel/jira-cli#installation", IsURL: true},
+			{Platform: "", Label: "Docker", Command: "docker pull ghcr.io/ankitpokhrel/jira-cli:latest"},
+		},
+		AuthSteps: []string{"jira init"},
+	}
+}
+
+// LinearInstallInfo returns installation info for Linear CLI
+func LinearInstallInfo() *ProviderInstallInfo {
+	return &ProviderInstallInfo{
+		CLIName:      "linear",
+		ProviderName: "Linear",
+		InstallOptions: []InstallOption{
+			{Platform: PlatformMacOS, Label: "macOS", Command: "brew install schpet/tap/linear"},
+			{Platform: "", Label: "Deno", Command: "deno install -A --reload -f -g -n linear jsr:@schpet/linear-cli"},
+			{Platform: "", Label: "Other", Command: "See https://github.com/schpet/linear-cli#installation", IsURL: true},
+		},
+		AuthSteps: []string{
+			"Create API key at https://linear.app/settings/account/security",
+			"Set environment variable: export LINEAR_API_KEY=lin_api_...",
+		},
+	}
+}

--- a/internal/cmd/install_instructions_test.go
+++ b/internal/cmd/install_instructions_test.go
@@ -1,0 +1,264 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGitHubInstallInfo(t *testing.T) {
+	info := GitHubInstallInfo()
+
+	if info.CLIName != "gh" {
+		t.Errorf("expected CLIName 'gh', got '%s'", info.CLIName)
+	}
+
+	if info.ProviderName != "GitHub" {
+		t.Errorf("expected ProviderName 'GitHub', got '%s'", info.ProviderName)
+	}
+
+	if len(info.InstallOptions) != 3 {
+		t.Errorf("expected 3 install options, got %d", len(info.InstallOptions))
+	}
+
+	if len(info.AuthSteps) != 1 || info.AuthSteps[0] != "gh auth login" {
+		t.Errorf("expected auth step 'gh auth login', got %v", info.AuthSteps)
+	}
+}
+
+func TestGitLabInstallInfo(t *testing.T) {
+	info := GitLabInstallInfo()
+
+	if info.CLIName != "glab" {
+		t.Errorf("expected CLIName 'glab', got '%s'", info.CLIName)
+	}
+
+	if info.ProviderName != "GitLab" {
+		t.Errorf("expected ProviderName 'GitLab', got '%s'", info.ProviderName)
+	}
+
+	if len(info.InstallOptions) != 3 {
+		t.Errorf("expected 3 install options, got %d", len(info.InstallOptions))
+	}
+
+	if len(info.AuthSteps) != 1 || info.AuthSteps[0] != "glab auth login" {
+		t.Errorf("expected auth step 'glab auth login', got %v", info.AuthSteps)
+	}
+}
+
+func TestJIRAInstallInfo(t *testing.T) {
+	info := JIRAInstallInfo()
+
+	if info.CLIName != "jira" {
+		t.Errorf("expected CLIName 'jira', got '%s'", info.CLIName)
+	}
+
+	if info.ProviderName != "JIRA" {
+		t.Errorf("expected ProviderName 'JIRA', got '%s'", info.ProviderName)
+	}
+
+	if len(info.InstallOptions) != 3 {
+		t.Errorf("expected 3 install options, got %d", len(info.InstallOptions))
+	}
+
+	if len(info.AuthSteps) != 1 || info.AuthSteps[0] != "jira init" {
+		t.Errorf("expected auth step 'jira init', got %v", info.AuthSteps)
+	}
+}
+
+func TestLinearInstallInfo(t *testing.T) {
+	info := LinearInstallInfo()
+
+	if info.CLIName != "linear" {
+		t.Errorf("expected CLIName 'linear', got '%s'", info.CLIName)
+	}
+
+	if info.ProviderName != "Linear" {
+		t.Errorf("expected ProviderName 'Linear', got '%s'", info.ProviderName)
+	}
+
+	if len(info.InstallOptions) != 3 {
+		t.Errorf("expected 3 install options, got %d", len(info.InstallOptions))
+	}
+
+	// Check that correct tap is used
+	found := false
+	for _, opt := range info.InstallOptions {
+		if strings.Contains(opt.Command, "schpet/tap/linear") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected install option with 'schpet/tap/linear'")
+	}
+
+	if len(info.AuthSteps) != 2 {
+		t.Errorf("expected 2 auth steps for Linear, got %d", len(info.AuthSteps))
+	}
+
+	// Check that auth steps mention API key
+	hasAPIKeyStep := false
+	for _, step := range info.AuthSteps {
+		if strings.Contains(step, "LINEAR_API_KEY") {
+			hasAPIKeyStep = true
+			break
+		}
+	}
+	if !hasAPIKeyStep {
+		t.Error("expected auth step mentioning LINEAR_API_KEY")
+	}
+}
+
+func TestFormatNotInstalledError(t *testing.T) {
+	info := &ProviderInstallInfo{
+		CLIName:      "test",
+		ProviderName: "Test",
+		InstallOptions: []InstallOption{
+			{Platform: PlatformMacOS, Label: "macOS", Command: "brew install test"},
+			{Platform: PlatformLinux, Label: "Linux", Command: "apt install test"},
+		},
+		AuthSteps: []string{"test auth"},
+	}
+
+	msg := info.FormatNotInstalledError()
+
+	if !strings.Contains(msg, "test CLI is not installed") {
+		t.Error("expected message to contain 'test CLI is not installed'")
+	}
+
+	if !strings.Contains(msg, "Install with:") {
+		t.Error("expected message to contain 'Install with:'")
+	}
+
+	if !strings.Contains(msg, "After installation:") {
+		t.Error("expected message to contain 'After installation:'")
+	}
+
+	if !strings.Contains(msg, "test auth") {
+		t.Error("expected message to contain auth step")
+	}
+}
+
+func TestFormatNotInstalledError_URLOption(t *testing.T) {
+	info := &ProviderInstallInfo{
+		CLIName:      "test",
+		ProviderName: "Test",
+		InstallOptions: []InstallOption{
+			{Platform: "", Label: "Other", Command: "https://example.com/install", IsURL: true},
+		},
+		AuthSteps: []string{},
+	}
+
+	msg := info.FormatNotInstalledError()
+
+	if !strings.Contains(msg, "See https://example.com/install") {
+		t.Errorf("expected URL to be prefixed with 'See', got: %s", msg)
+	}
+}
+
+func TestFormatNotAuthenticatedError(t *testing.T) {
+	info := &ProviderInstallInfo{
+		CLIName:      "test",
+		ProviderName: "Test",
+		AuthSteps:    []string{"test auth login"},
+	}
+
+	msg := info.FormatNotAuthenticatedError()
+
+	if !strings.Contains(msg, "test CLI is not authenticated") {
+		t.Error("expected message to contain 'test CLI is not authenticated'")
+	}
+
+	if !strings.Contains(msg, "Run: test auth login") {
+		t.Errorf("expected message to contain 'Run: test auth login', got: %s", msg)
+	}
+}
+
+func TestFormatNotAuthenticatedError_MultipleSteps(t *testing.T) {
+	info := &ProviderInstallInfo{
+		CLIName:      "test",
+		ProviderName: "Test",
+		AuthSteps:    []string{"Step 1", "Step 2"},
+	}
+
+	msg := info.FormatNotAuthenticatedError()
+
+	if !strings.Contains(msg, "Configure with:") {
+		t.Error("expected message to contain 'Configure with:' for multiple steps")
+	}
+
+	if !strings.Contains(msg, "Step 1") || !strings.Contains(msg, "Step 2") {
+		t.Error("expected message to contain all auth steps")
+	}
+}
+
+func TestFormatNotAuthenticatedError_NoSteps(t *testing.T) {
+	info := &ProviderInstallInfo{
+		CLIName:      "test",
+		ProviderName: "Test",
+		AuthSteps:    []string{},
+	}
+
+	msg := info.FormatNotAuthenticatedError()
+
+	if msg != "test CLI is not authenticated" {
+		t.Errorf("expected simple message, got: %s", msg)
+	}
+}
+
+func TestGetRelevantOptions_PlatformSpecific(t *testing.T) {
+	info := &ProviderInstallInfo{
+		CLIName:      "test",
+		ProviderName: "Test",
+		InstallOptions: []InstallOption{
+			{Platform: PlatformMacOS, Label: "macOS", Command: "brew install test"},
+			{Platform: PlatformLinux, Label: "Linux", Command: "apt install test"},
+			{Platform: PlatformWindows, Label: "Windows", Command: "winget install test"},
+			{Platform: "", Label: "Other", Command: "https://example.com", IsURL: true},
+		},
+	}
+
+	// Test macOS
+	options := info.getRelevantOptions(PlatformMacOS)
+	if len(options) != 2 { // macOS + Other
+		t.Errorf("expected 2 options for macOS, got %d", len(options))
+	}
+	if options[0].Label != "macOS" {
+		t.Errorf("expected first option to be macOS, got %s", options[0].Label)
+	}
+
+	// Test Linux
+	options = info.getRelevantOptions(PlatformLinux)
+	if len(options) != 2 { // Linux + Other
+		t.Errorf("expected 2 options for Linux, got %d", len(options))
+	}
+	if options[0].Label != "Linux" {
+		t.Errorf("expected first option to be Linux, got %s", options[0].Label)
+	}
+}
+
+func TestGetRelevantOptions_NoPlatformMatch(t *testing.T) {
+	info := &ProviderInstallInfo{
+		CLIName:      "test",
+		ProviderName: "Test",
+		InstallOptions: []InstallOption{
+			{Platform: PlatformMacOS, Label: "macOS", Command: "brew install test"},
+		},
+	}
+
+	// Test with a platform that has no specific option
+	options := info.getRelevantOptions(PlatformLinux)
+	if len(options) != 1 {
+		t.Errorf("expected 1 option when no platform match, got %d", len(options))
+	}
+}
+
+func TestGetCurrentPlatform(t *testing.T) {
+	platform := GetCurrentPlatform()
+
+	// Just verify it returns a valid platform (darwin, linux, or windows)
+	if platform != PlatformMacOS && platform != PlatformLinux && platform != PlatformWindows {
+		// This is fine - could be running on FreeBSD or other OS
+		t.Logf("Current platform: %s", platform)
+	}
+}

--- a/internal/cmd/provider_factory.go
+++ b/internal/cmd/provider_factory.go
@@ -49,12 +49,14 @@ func GetProviderForRepository(repo *git.Repository) (providers.Provider, error) 
 // newGitHubProvider creates a GitHub provider
 func newGitHubProvider(repo *git.Repository) (providers.Provider, error) {
 	executor := github.NewGitHubExecutor()
+	installInfo := GitHubInstallInfo()
+
 	if !github.IsInstalled(executor) {
-		return nil, errors.New("gh CLI is not installed. Install with: brew install gh")
+		return nil, errors.New(installInfo.FormatNotInstalledError())
 	}
 
 	if err := github.IsAuthenticated(executor); err != nil {
-		return nil, errors.New("gh CLI is not authenticated. Run: gh auth login")
+		return nil, errors.New(installInfo.FormatNotAuthenticatedError())
 	}
 
 	client, err := github.NewClient(repo.RootPath)
@@ -67,12 +69,14 @@ func newGitHubProvider(repo *git.Repository) (providers.Provider, error) {
 
 // handleGitHubClientError converts GitHub client errors to user-friendly messages
 func handleGitHubClientError(err error) error {
+	installInfo := GitHubInstallInfo()
+
 	if errors.Is(err, github.ErrGHNotInstalled) {
-		return errors.New("gh CLI is not installed. Install with: brew install gh")
+		return errors.New(installInfo.FormatNotInstalledError())
 	}
 
 	if errors.Is(err, github.ErrGHNotAuthenticated) {
-		return errors.New("gh CLI is not authenticated. Run: gh auth login")
+		return errors.New(installInfo.FormatNotAuthenticatedError())
 	}
 
 	return fmt.Errorf("failed to initialize GitHub client: %w", err)
@@ -201,12 +205,14 @@ func (g *githubProviderShim) ProviderType() string {
 // newGitLabProvider creates a GitLab provider
 func newGitLabProvider(repo *git.Repository) (providers.Provider, error) {
 	executor := gitlab.NewGitLabExecutor()
+	installInfo := GitLabInstallInfo()
+
 	if !gitlab.IsInstalled(executor) {
-		return nil, errors.New("glab CLI is not installed. Install with: brew install glab")
+		return nil, errors.New(installInfo.FormatNotInstalledError())
 	}
 
 	if err := gitlab.IsAuthenticated(executor); err != nil {
-		return nil, errors.New("glab CLI is not authenticated. Run: glab auth login")
+		return nil, errors.New(installInfo.FormatNotAuthenticatedError())
 	}
 
 	client, err := gitlab.NewClient(repo.RootPath)
@@ -219,12 +225,14 @@ func newGitLabProvider(repo *git.Repository) (providers.Provider, error) {
 
 // handleGitLabClientError converts GitLab client errors to user-friendly messages
 func handleGitLabClientError(err error) error {
+	installInfo := GitLabInstallInfo()
+
 	if errors.Is(err, gitlab.ErrGlabNotInstalled) {
-		return errors.New("glab CLI is not installed. Install with: brew install glab")
+		return errors.New(installInfo.FormatNotInstalledError())
 	}
 
 	if errors.Is(err, gitlab.ErrGlabNotAuthenticated) {
-		return errors.New("glab CLI is not authenticated. Run: glab auth login")
+		return errors.New(installInfo.FormatNotAuthenticatedError())
 	}
 
 	return fmt.Errorf("failed to initialize GitLab client: %w", err)
@@ -338,15 +346,14 @@ func (g *gitlabProviderShim) ProviderType() string {
 
 // newJIRAProvider creates a JIRA provider
 func newJIRAProvider() (providers.Provider, error) {
+	installInfo := JIRAInstallInfo()
+
 	if !jira.IsInstalled() {
-		return nil, fmt.Errorf("jira CLI is not installed. Install with:\n" +
-			"  brew install ankitpokhrel/jira-cli/jira-cli\n" +
-			"  or see https://github.com/ankitpokhrel/jira-cli#installation\n" +
-			"After installation, run: jira init")
+		return nil, errors.New(installInfo.FormatNotInstalledError())
 	}
 
 	if err := jira.IsConfigured(); err != nil {
-		return nil, fmt.Errorf("jira CLI is not configured. Run: jira init")
+		return nil, errors.New(installInfo.FormatNotAuthenticatedError())
 	}
 
 	// Get repository for configuration
@@ -401,12 +408,14 @@ func autoDetectProvider(repo *git.Repository) (providers.Provider, error) {
 // newLinearProvider creates a Linear provider
 func newLinearProvider(repo *git.Repository) (providers.Provider, error) {
 	executor := linear.NewExecutor()
+	installInfo := LinearInstallInfo()
+
 	if !linear.IsInstalled(executor) {
-		return nil, errors.New("linear CLI is not installed. Install with: brew install linear\nAfter installation, run: linear auth")
+		return nil, errors.New(installInfo.FormatNotInstalledError())
 	}
 
 	if err := linear.IsAuthenticated(executor); err != nil {
-		return nil, errors.New("linear CLI is not authenticated. Run: linear auth")
+		return nil, errors.New(installInfo.FormatNotAuthenticatedError())
 	}
 
 	cfg := git.NewConfig(repo.RootPath)
@@ -421,12 +430,14 @@ func newLinearProvider(repo *git.Repository) (providers.Provider, error) {
 
 // handleLinearClientError converts Linear client errors to user-friendly messages
 func handleLinearClientError(err error) error {
+	installInfo := LinearInstallInfo()
+
 	if errors.Is(err, linear.ErrLinearNotInstalled) {
-		return errors.New("linear CLI is not installed. Install with: brew install linear")
+		return errors.New(installInfo.FormatNotInstalledError())
 	}
 
 	if errors.Is(err, linear.ErrLinearNotAuthenticated) {
-		return errors.New("linear CLI is not authenticated. Run: linear auth")
+		return errors.New(installInfo.FormatNotAuthenticatedError())
 	}
 
 	if errors.Is(err, linear.ErrNoTeamConfigured) {


### PR DESCRIPTION
## Summary
- Add structured install instructions helper (`install_instructions.go`) with platform detection
- Show only relevant install commands for the host OS (macOS, Linux, Windows)
- Include authentication/configuration steps for each provider
- Fix Linear CLI to use correct tap (`schpet/tap/linear`) and API key auth

## Provider Install Instructions

| Provider | macOS | Linux | Windows | Auth |
|----------|-------|-------|---------|------|
| GitHub | `brew install gh` | docs link | `winget install GitHub.cli` | `gh auth login` |
| GitLab | `brew install glab` | docs link | `scoop install glab` | `glab auth login` |
| JIRA | `brew install ankitpokhrel/jira-cli/jira-cli` | docs link | Docker | `jira init` |
| Linear | `brew install schpet/tap/linear` | Deno/docs | Deno/docs | `LINEAR_API_KEY` env var |

## Test plan
- [x] All existing tests pass
- [x] New unit tests for install instructions helper
- [x] Linter passes with 0 issues

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)