### PR TITLE
Fix GitHub PR-issue auto-association and enforce branch naming with bats tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,3 +25,17 @@ jobs:
 
       - name: Run ShellCheck validation
         run: ci/validate.sh
+
+  run-tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install bats
+        run: sudo apt-get install -y bats
+
+      - name: Run bats tests
+        run: bats tests/

--- a/src/commands/issue.sh
+++ b/src/commands/issue.sh
@@ -342,6 +342,16 @@ Ask clarifying questions about the intended work if you can think of any."
     printf '\033]0;GitHub Issue #%s - %s\007' "$issue_id" "$title"
   fi
 
+  # For GitHub: register branch-issue link so PRs created from this branch
+  # automatically associate with the issue in the Development section
+  if [[ "$provider" == "github" ]]; then
+    local base_branch
+    base_branch=$(git symbolic-ref --short HEAD 2>/dev/null || echo "main")
+    if gh issue develop "$issue_id" --name "$branch_name" --base "$base_branch" >/dev/null 2>&1; then
+      gum style --foreground 2 "Branch linked to issue #${issue_id}"
+    fi
+  fi
+
   _aw_create_worktree "$branch_name" "$ai_context"
 }
 

--- a/src/lib/utils.sh
+++ b/src/lib/utils.sh
@@ -48,7 +48,7 @@ _aw_generate_random_name() {
 }
 
 _aw_sanitize_branch_name() {
-  echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//;s/-$//'
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed -E 's/-+/-/g' | sed 's/^-//;s/-$//'
 }
 
 _aw_get_file_mtime() {

--- a/tests/branch_naming.bats
+++ b/tests/branch_naming.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+# Tests for branch naming conventions
+#
+# Enforces that branch names for GitHub issues preserve the issue number so that:
+# 1. _aw_extract_issue_number can find it for display/cleanup
+# 2. gh issue develop can be called to register the branch-issue link on GitHub
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+
+setup() {
+  # Stub external-tool functions before sourcing so common.sh can load cleanly
+  _aw_get_issue_provider() { echo "github"; }
+
+  # Source only the pure utility functions under test
+  # shellcheck source=../src/lib/utils.sh
+  source "${REPO_ROOT}/src/lib/utils.sh"
+  # shellcheck source=../src/providers/common.sh
+  source "${REPO_ROOT}/src/providers/common.sh"
+}
+
+# ===== _aw_sanitize_branch_name =====
+
+@test "_aw_sanitize_branch_name: spaces become hyphens" {
+  run _aw_sanitize_branch_name "hello world"
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello-world" ]
+}
+
+@test "_aw_sanitize_branch_name: uppercase becomes lowercase" {
+  run _aw_sanitize_branch_name "Fix Login Bug"
+  [ "$status" -eq 0 ]
+  [ "$output" = "fix-login-bug" ]
+}
+
+@test "_aw_sanitize_branch_name: special chars become hyphens" {
+  run _aw_sanitize_branch_name "fix: auth & session (critical)"
+  [ "$status" -eq 0 ]
+  [ "$output" = "fix-auth-session-critical" ]
+}
+
+@test "_aw_sanitize_branch_name: consecutive hyphens are collapsed" {
+  run _aw_sanitize_branch_name "fix--double  space"
+  [ "$status" -eq 0 ]
+  [ "$output" = "fix-double-space" ]
+}
+
+@test "_aw_sanitize_branch_name: leading and trailing hyphens are stripped" {
+  run _aw_sanitize_branch_name "-fix-me-"
+  [ "$status" -eq 0 ]
+  [ "$output" = "fix-me" ]
+}
+
+@test "_aw_sanitize_branch_name: produces valid git branch name characters" {
+  run _aw_sanitize_branch_name "Feature/Add OAuth2 Support (v2.0)"
+  [ "$status" -eq 0 ]
+  # Output should only contain lowercase alphanumeric and hyphens
+  [[ "$output" =~ ^[a-z0-9-]+$ ]]
+}
+
+# ===== _aw_extract_issue_number =====
+
+@test "_aw_extract_issue_number: extracts from work/N-description format" {
+  run _aw_extract_issue_number "work/123-fix-login-bug"
+  [ "$status" -eq 0 ]
+  [ "$output" = "123" ]
+}
+
+@test "_aw_extract_issue_number: extracts from plain N-description format" {
+  run _aw_extract_issue_number "456-add-feature"
+  [ "$status" -eq 0 ]
+  [ "$output" = "456" ]
+}
+
+@test "_aw_extract_issue_number: handles multi-digit issue numbers" {
+  run _aw_extract_issue_number "work/9999-big-issue"
+  [ "$status" -eq 0 ]
+  [ "$output" = "9999" ]
+}
+
+@test "_aw_extract_issue_number: handles single-digit issue numbers" {
+  run _aw_extract_issue_number "work/7-tiny-fix"
+  [ "$status" -eq 0 ]
+  [ "$output" = "7" ]
+}
+
+# ===== GitHub issue branch naming invariant =====
+# The default suggested branch name (work/${issue_id}-${sanitized}) must preserve
+# the issue number so PRs can be auto-associated via gh issue develop
+
+@test "GitHub issue branch name preserves issue number" {
+  local issue_id="123"
+  local title="Fix the login bug"
+  local sanitized
+  sanitized=$(_aw_sanitize_branch_name "$title" | cut -c1-40)
+  local branch_name="work/${issue_id}-${sanitized}"
+
+  run _aw_extract_issue_number "$branch_name"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$issue_id" ]
+}
+
+@test "GitHub issue branch name preserves issue number with special chars in title" {
+  local issue_id="456"
+  local title="Fix: auth & session management (critical)"
+  local sanitized
+  sanitized=$(_aw_sanitize_branch_name "$title" | cut -c1-40)
+  local branch_name="work/${issue_id}-${sanitized}"
+
+  run _aw_extract_issue_number "$branch_name"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$issue_id" ]
+}
+
+@test "GitHub issue branch name preserves issue number with long title truncated to 40 chars" {
+  local issue_id="789"
+  local title="This is a very long issue title that exceeds the forty character limit we set for branch names"
+  local sanitized
+  sanitized=$(_aw_sanitize_branch_name "$title" | cut -c1-40)
+  local branch_name="work/${issue_id}-${sanitized}"
+
+  run _aw_extract_issue_number "$branch_name"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$issue_id" ]
+}
+
+@test "GitHub issue branch name format matches work/N-description pattern" {
+  local issue_id="42"
+  local title="Implement dark mode"
+  local sanitized
+  sanitized=$(_aw_sanitize_branch_name "$title" | cut -c1-40)
+  local branch_name="work/${issue_id}-${sanitized}"
+
+  # Branch must start with work/ prefix
+  [[ "$branch_name" =~ ^work/ ]]
+  # Branch must contain the issue number immediately after work/
+  [[ "$branch_name" =~ ^work/[0-9]+ ]]
+  # _aw_extract_issue_number must recover the original issue id
+  run _aw_extract_issue_number "$branch_name"
+  [ "$output" = "$issue_id" ]
+}


### PR DESCRIPTION
## Summary

- Use `gh issue develop` when creating worktrees for GitHub issues so PRs automatically appear in the issue's Development section — no more manual linking or `Closes #N` keywords needed
- Fix `_aw_sanitize_branch_name` to use `sed -E` so consecutive hyphens collapse correctly on macOS BSD sed (was silently broken)
- Add `tests/branch_naming.bats` (14 tests) enforcing that the `work/N-description` branch format always preserves the issue number
- Add a `run-tests` CI job that installs bats and runs `tests/` on every PR

## How it works

Previously, `auto-worktree issue` created branches with `git worktree add -b`, which GitHub has no knowledge of. Now, for GitHub issues, we call:

```bash
gh issue develop "$issue_id" --name "$branch_name" --base "$base_branch"
```

This registers the branch-issue link on GitHub's backend. Any PR subsequently created from that branch automatically shows in the issue's **Development** sidebar and can auto-close the issue on merge. If `gh issue develop` fails (no network, non-GitHub context, etc.) the flow silently falls back to normal worktree creation.

## Test Plan
- [x] All 14 bats tests pass locally (`bats tests/`)
- [x] `shellcheck` passes on all modified files
- [x] CI jobs added to validate on every PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)