### PR TITLE
Integrate corporate prefix wrapper into AI tool selection flow

### DIFF
--- a/src/lib/ai.sh
+++ b/src/lib/ai.sh
@@ -36,20 +36,15 @@ _setup_ai_cmd() {
   local tool_type="$1"
   local default_path="$2"
 
-  # Check for a corporate wrapper command override
-  local custom_cmd
-  custom_cmd=$(_aw_get_ai_tool_cmd)
+  local prefix
+  prefix=$(_aw_get_ai_tool_cmd)
   local cmd_parts=()
 
-  if [[ -n "$custom_cmd" ]]; then
-    local base_cmd="${custom_cmd%% *}"
-    if command -v "$base_cmd" &>/dev/null; then
-      read -ra cmd_parts <<< "$custom_cmd"
-    fi
-  fi
-
-  # Fall back to auto-detected path if no valid override
-  if [[ ${#cmd_parts[@]} -eq 0 ]]; then
+  if [[ -n "$prefix" ]] && command -v "$prefix" &>/dev/null; then
+    local tool_bin
+    tool_bin=$(basename "$default_path")
+    cmd_parts=("$prefix" "$tool_bin")
+  else
     cmd_parts=("$default_path")
   fi
 
@@ -502,6 +497,9 @@ _resolve_ai_command() {
       esac
       echo ""
     fi
+
+    echo ""
+    _aw_configure_corporate_wrapper
 
     return 0
   fi

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -365,68 +365,47 @@ _aw_get_ai_tool_cmd() {
 }
 
 _aw_set_ai_tool_cmd() {
-  # Set the corporate AI tool wrapper command
-  # Args: $1 = command (e.g. "goog claude"), $2 = scope (--local or --global, default: --local)
+  # Set the corporate CLI prefix (e.g. "goog" or "appl")
+  # Args: $1 = prefix (e.g. "goog"), $2 = scope (--local or --global, default: --local)
   local cmd="$1"
   local scope="${2:---local}"
   if [[ -z "$cmd" ]]; then
     git config "$scope" --unset auto-worktree.ai-tool-cmd 2>/dev/null || true
   else
     git config "$scope" auto-worktree.ai-tool-cmd "$cmd"
-    gum style --foreground 2 "✓ Corporate AI command set to: $cmd"
+    gum style --foreground 2 "✓ Corporate CLI prefix set to: $cmd"
   fi
 }
 
 _aw_configure_corporate_wrapper() {
-  # Interactive configuration for corporate AI tool wrappers
-  # (e.g. "goog claude" for Google engineers, "appl codex" for Apple engineers)
+  # Interactive configuration for corporate AI CLI prefix wrappers
+  # (e.g. "goog" for Google engineers, "appl" for Apple engineers)
   echo ""
-  gum style --foreground 6 "Configure Corporate AI Tool Wrapper"
+  gum style --foreground 6 "Configure Corporate CLI Prefix"
   echo ""
-  echo "Some companies provide internal CLI wrappers for AI tools,"
-  echo "e.g. 'goog claude' or 'appl codex'."
+  echo "Some companies provide internal CLI wrappers for AI tools."
+  echo "Enter the prefix (e.g. 'goog' for 'goog claude', 'appl' for 'appl codex')."
   echo ""
 
-  local current_cmd=$(_aw_get_ai_tool_cmd)
-  local cmd
-  cmd=$(gum input \
-    --placeholder "e.g. goog claude, appl codex" \
-    --value "$current_cmd" \
-    --header "Corporate AI tool command (leave empty to clear):")
+  local current_prefix=$(_aw_get_ai_tool_cmd)
+  local prefix
+  prefix=$(gum input \
+    --placeholder "e.g. goog, appl" \
+    --value "$current_prefix" \
+    --header "Corporate CLI prefix wrapper (leave empty to skip/clear):")
 
-  if [[ -z "$cmd" ]]; then
-    if [[ -n "$current_cmd" ]]; then
-      if gum confirm "Clear corporate wrapper command?"; then
+  if [[ -z "$prefix" ]]; then
+    if [[ -n "$current_prefix" ]]; then
+      if gum confirm "Clear corporate prefix wrapper?"; then
         git config --local --unset auto-worktree.ai-tool-cmd 2>/dev/null || true
         git config --global --unset auto-worktree.ai-tool-cmd 2>/dev/null || true
-        gum style --foreground 2 "✓ Corporate AI wrapper cleared"
+        gum style --foreground 2 "✓ Corporate AI prefix cleared"
       else
         gum style --foreground 3 "Cancelled"
       fi
-    else
-      gum style --foreground 3 "Cancelled"
     fi
     return 0
   fi
-
-  # Determine which underlying AI tool this wraps
-  echo ""
-  local type_choice
-  type_choice=$(gum choose --header "Which AI tool does this wrap?" \
-    "Claude Code (Anthropic)" \
-    "Codex CLI (OpenAI)" \
-    "Gemini CLI (Google)" \
-    "Google Jules CLI (Google)" \
-    "Back")
-
-  local tool_type=""
-  case "$type_choice" in
-    "Claude Code (Anthropic)") tool_type="claude" ;;
-    "Codex CLI (OpenAI)") tool_type="codex" ;;
-    "Gemini CLI (Google)") tool_type="gemini" ;;
-    "Google Jules CLI (Google)") tool_type="jules" ;;
-    *) return 0 ;;
-  esac
 
   # Choose scope: project or global
   echo ""
@@ -438,14 +417,12 @@ _aw_configure_corporate_wrapper() {
   local scope="--local"
   [[ "$scope_choice" == "Globally (all projects)" ]] && scope="--global"
 
-  _aw_set_ai_tool_cmd "$cmd" "$scope"
-  git config "$scope" auto-worktree.ai-tool "$tool_type"
+  _aw_set_ai_tool_cmd "$prefix" "$scope"
 
   echo ""
-  gum style --foreground 2 "✓ Corporate wrapper configured:"
-  echo "  Command:  $cmd"
-  echo "  Wraps:    $tool_type"
-  echo "  Scope:    ${scope/--/}"
+  gum style --foreground 2 "✓ Corporate prefix configured:"
+  echo "  Prefix: $prefix"
+  echo "  Scope:  ${scope/--/}"
   echo ""
 }
 

--- a/src/lib/settings.sh
+++ b/src/lib/settings.sh
@@ -60,7 +60,7 @@ _aw_show_settings_summary() {
   local pr_autoselect=$(_aw_get_pr_autoselect)
 
   local ai_cmd_line=""
-  [[ -n "$ai_tool_cmd" ]] && ai_cmd_line="Corporate AI command: $ai_tool_cmd"
+  [[ -n "$ai_tool_cmd" ]] && ai_cmd_line="AI prefix wrapper: $ai_tool_cmd"
 
   if [[ -n "$ai_cmd_line" ]]; then
     gum style --border rounded --padding "0 1" --border-foreground 4 \
@@ -133,8 +133,7 @@ _aw_show_settings_warnings() {
   local ai_tool_cmd=$(_aw_get_ai_tool_cmd)
 
   if [[ -n "$ai_tool_cmd" ]]; then
-    local base_cmd="${ai_tool_cmd%% *}"
-    command -v "$base_cmd" &>/dev/null || warnings+=("Corporate AI command '$ai_tool_cmd' not found (base command '$base_cmd' is not in PATH).")
+    command -v "$ai_tool_cmd" &>/dev/null || warnings+=("AI prefix wrapper '$ai_tool_cmd' not found in PATH.")
   elif [[ -n "$ai_pref" ]] && [[ "$ai_pref" != "skip" ]]; then
     case "$ai_pref" in
       claude)
@@ -220,7 +219,6 @@ _aw_settings_ai_tool() {
       "Gemini CLI" \
       "Google Jules CLI" \
       "Skip AI tool" \
-      "Corporate wrapper / Custom command" \
       "Back")
 
     case "$choice" in
@@ -231,25 +229,26 @@ _aw_settings_ai_tool() {
       "Claude Code")
         _save_ai_preference "claude"
         gum style --foreground 2 "✓ AI tool preference set to Claude Code"
+        _aw_configure_corporate_wrapper
         ;;
       "Codex CLI")
         _save_ai_preference "codex"
         gum style --foreground 2 "✓ AI tool preference set to Codex CLI"
+        _aw_configure_corporate_wrapper
         ;;
       "Gemini CLI")
         _save_ai_preference "gemini"
         gum style --foreground 2 "✓ AI tool preference set to Gemini CLI"
+        _aw_configure_corporate_wrapper
         ;;
       "Google Jules CLI")
         _save_ai_preference "jules"
         gum style --foreground 2 "✓ AI tool preference set to Google Jules CLI"
+        _aw_configure_corporate_wrapper
         ;;
       "Skip AI tool")
         _save_ai_preference "skip"
         gum style --foreground 2 "✓ AI tool preference set to skip"
-        ;;
-      "Corporate wrapper / Custom command")
-        _aw_configure_corporate_wrapper
         ;;
       *) return 0 ;;
     esac

--- a/src/main.sh
+++ b/src/main.sh
@@ -20,8 +20,7 @@
 #   git config auto-worktree.gitlab-project <GROUP/PROJECT>     # Set default GitLab project path
 #   git config auto-worktree.linear-team <TEAM>                 # Set default Linear team
 #   git config auto-worktree.ai-tool <name>                     # claude|codex|gemini|jules|skip
-#   git config auto-worktree.ai-tool-cmd <cmd>                  # Corporate wrapper command, e.g. "goog claude" or "appl codex"
-#   git config --global auto-worktree.ai-tool-cmd <cmd>         # Same but stored globally for all projects
+#   git config auto-worktree.ai-tool-cmd <prefix>               # Corporate CLI prefix, e.g. "goog" or "appl"
 #   git config auto-worktree.issue-autoselect <bool>            # true/false for AI auto-select
 #   git config auto-worktree.pr-autoselect <bool>               # true/false for AI auto-select
 #   git config auto-worktree.run-hooks <bool>                   # true/false to enable/disable git hooks (default: true)


### PR DESCRIPTION
## Summary
- Corporate CLI prefix (e.g. `goog`, `appl`) is now prompted inline when selecting any AI tool in settings or the interactive multi-tool picker — no longer a separate menu option
- `auto-worktree.ai-tool-cmd` now stores just the prefix (e.g. `"goog"`) instead of the full command (e.g. `"goog claude"`), decoupling it from the tool name
- `_setup_ai_cmd()` builds `[prefix, basename(tool), flags...]` at execution time, so switching tools doesn't require reconfiguring the wrapper

## Test Plan
- [ ] `aw settings` → AI tool preference → pick "Claude Code" → prefix prompt appears → enter `goog` → `git config auto-worktree.ai-tool-cmd` returns `goog`
- [ ] With multiple AI tools installed: run `aw` → pick one → prefix prompt appears after save-default step
- [ ] With only one AI tool: no interactive prompts, prefix NOT prompted (solo-tool path unchanged)
- [ ] When prefix is set: AI is launched as `goog claude --dangerously-skip-permissions`
- [ ] Settings summary shows `AI prefix wrapper: goog`
- [ ] Set `ai-tool-cmd` to nonexistent prefix → settings shows warning

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)