### PR TITLE
Handle legacy space-delimited ai-tool-cmd values

### DIFF
--- a/src/lib/ai.sh
+++ b/src/lib/ai.sh
@@ -449,18 +449,19 @@ _resolve_ai_command() {
 
     local choice=$(gum choose "${options[@]}")
 
+    local chosen_tool="" chosen_path=""
     case "$choice" in
       "Claude Code (Anthropic)")
-        _setup_ai_cmd claude "$claude_path"
+        chosen_tool="claude"; chosen_path="$claude_path"
         ;;
       "Codex CLI (OpenAI)")
-        _setup_ai_cmd codex "$codex_path"
+        chosen_tool="codex"; chosen_path="$codex_path"
         ;;
       "Gemini CLI (Google)")
-        _setup_ai_cmd gemini "$gemini_path"
+        chosen_tool="gemini"; chosen_path="$gemini_path"
         ;;
       "Google Jules CLI (Google)")
-        _setup_ai_cmd jules "$jules_path"
+        chosen_tool="jules"; chosen_path="$jules_path"
         ;;
       "Skip - don't use an AI tool")
         AI_CMD=(skip)
@@ -471,6 +472,8 @@ _resolve_ai_command() {
         return 1
         ;;
     esac
+
+    _setup_ai_cmd "$chosen_tool" "$chosen_path"
 
     # Ask if this choice should be saved
     echo ""
@@ -502,6 +505,8 @@ _resolve_ai_command() {
 
     echo ""
     _aw_configure_corporate_wrapper
+    # Rebuild AI_CMD with the newly saved prefix (if user just configured one)
+    _setup_ai_cmd "$chosen_tool" "$chosen_path"
 
     return 0
   fi

--- a/src/lib/ai.sh
+++ b/src/lib/ai.sh
@@ -36,8 +36,10 @@ _setup_ai_cmd() {
   local tool_type="$1"
   local default_path="$2"
 
-  local prefix
-  prefix=$(_aw_get_ai_tool_cmd)
+  local raw_cmd
+  raw_cmd=$(_aw_get_ai_tool_cmd)
+  # Support legacy "goog claude" format by taking only the first word as the prefix
+  local prefix="${raw_cmd%% *}"
   local cmd_parts=()
 
   if [[ -n "$prefix" ]] && command -v "$prefix" &>/dev/null; then


### PR DESCRIPTION
## Summary

Follow-up to #194. Fixes a P1 regression reported in PR review.

When upgrading from the prior `auto-worktree.ai-tool-cmd` format (`"goog claude"`) to the new prefix-only format, `_setup_ai_cmd` would call `command -v "goog claude"` (two words), which always fails. This caused a silent fallback to the unwrapped binary, breaking corporate environments that require the wrapper.

**Fix**: extract only the first word from the stored value as the prefix, so both formats work transparently:
- New format: `"goog"` → prefix = `goog` ✅
- Legacy format: `"goog claude"` → prefix = `goog` ✅ (auto-migrated, no reconfiguration needed)

## Test Plan
- [ ] Set `git config auto-worktree.ai-tool-cmd "goog claude"` (legacy format) → AI launches as `goog claude --dangerously-skip-permissions`
- [ ] Set `git config auto-worktree.ai-tool-cmd "goog"` (new format) → AI launches as `goog claude --dangerously-skip-permissions`
- [ ] No prefix set → AI launches as `claude --dangerously-skip-permissions` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)